### PR TITLE
chore: añadir .kiro/ a .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 *.class
+.claude/
+GEMINI.md
+.kiro/


### PR DESCRIPTION
Kiro CLI lee contexto vía .kiro/steering/context.md (symlink gestionado por myClaudeContext), igual que GEMINI.md. Se excluye del repo.